### PR TITLE
Added contributions guidlines file

### DIFF
--- a/HowToContribute.md
+++ b/HowToContribute.md
@@ -1,0 +1,19 @@
+# Description:
+The goal of this file is to help the larger community settle on some best practices when it comes to contributing. This is an open source project, so community contributions are the only way this will truly develop. Any help you give is greatly appreciated, big or small.
+
+## Issue Gardening:
+This is essentially how we keep track of what issues are presently at play and discuss solutions before attempting to fix them. 
+- When creating an issue ensure that you have first looked through all open issues so that no duplicates are made.
+- Please include a labels in new issues, such as "Documentation" or "Bug" or "Question". This helps others know what you may be looking for and direct focus. This is particularly true if you attach labels like [good first issue] so that newcomers can assess an issue for their skill set.
+- If the issue is bug related please include a text version of any output and clear description of how you created it.
+
+## Bug Fixing and Pull Requests:
+- When making a pull request include the number of the issue it is refrencing. This helps us keep track of which issues to close as well as ensure all needed changes are being addressed.
+- Use clear and succinct commit messages.
+- Keep your pull request to one issue. Smaller is better.
+- When describing the pull request don't assume past history with the issue. Please outline the goal of the changes.
+- If you need help with your code please include areas of concern to help reviewers know what they can do.
+- Add screen shots if you are including visual changes.
+- @mention devs that you specifically want to see the PR and mention why. Such as having experience with the issue.
+- Try to make all code as readable as possible and include comments where you can.
+


### PR DESCRIPTION
As per @AlbertCoolGuy suggestion in issue #23 I made a small contributions document. It might make more sense to include this in the readme file, but I feel like separating end user from developer with a pointer to this document at the end of the readme may help keep the readme and general product more approachable.

This is also just a simple outline of ideas, I don't have a lot of experience so additions and changes would be appreciated.