### PR TITLE
setup Gitter chat, and added readme badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,10 @@ dmypy.json
 # mypy
 
 # Pyre type checker
+.idea/
+.vs/
+.env
+env
+.pk
+.pem
+.pub

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 #                                                      BookOmatic
+[![Gitter](https://badges.gitter.im/BookOmatic/community.svg)](https://gitter.im/BookOmatic/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![GPL Licence](https://badges.frapsoft.com/os/gpl/gpl.svg?v=103)](https://opensource.org/licenses/GPL-3.0/)
+[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
+
 
 ## What is BookOmatic?
 - This is a project that intends to automate the process of booking meetings according to available time slots.


### PR DESCRIPTION
Given the diverse amount of contributors, and increasing complexity of the project, would be best if we had a single lightweight chatroom to have repo related discussions. 

And, here it is: [![Gitter](https://badges.gitter.im/BookOmatic/community.svg)](https://gitter.im/BookOmatic/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)